### PR TITLE
Update `metadata.yaml` for `squeezenet1_1`

### DIFF
--- a/torchbenchmark/models/squeezenet1_1/metadata.yaml
+++ b/torchbenchmark/models/squeezenet1_1/metadata.yaml
@@ -5,6 +5,9 @@ eval_benchmark: true
 eval_deterministic: false
 eval_nograd: true
 not_implemented:
-- test: train
+  - device: cpu
+    test: train
+  - device: cuda
+    test: train
 train_benchmark: true
 train_deterministic: false


### PR DESCRIPTION
Changes:
- `squeezenet1_1_train` changed so that it is only skipped on machines used by upstream CI