### PR TITLE
Install diffusers before error checking

### DIFF
--- a/torchbenchmark/canary_models/stable_diffusion_xl/install.py
+++ b/torchbenchmark/canary_models/stable_diffusion_xl/install.py
@@ -15,10 +15,10 @@ def load_model_checkpoint():
 
 
 if __name__ == "__main__":
+    install_diffusers()
     if not "HUGGING_FACE_HUB_TOKEN" in os.environ:
         warnings.warn(
             "Make sure to set `HUGGINGFACE_HUB_TOKEN` so you can download weights"
         )
     else:
-        install_diffusers()
         load_model_checkpoint()


### PR DESCRIPTION
`install_diffusers()` should be called before error checking for the token, otherwise instantiating the model errors out because diffusers is not installed. This is similar to how it's done for other models such as [stable_diffusion_unet](https://github.com/pytorch/benchmark/blob/main/torchbenchmark/models/stable_diffusion_unet/install.py#L18) and [stable_diffusion_text_encoder](https://github.com/pytorch/benchmark/blob/main/torchbenchmark/models/stable_diffusion_text_encoder/install.py)

bug example:
`python benchmark/run.py stable_diffusion_xl -t eval --metrics model_flops,cpu_peak_mem,ttfb`

```
Warning: The model stable_diffusion_xl cannot be found at core set.
Traceback (most recent call last):
  File "/nethome/iasonm/work/torch_upstream_wrapper/benchmark_wrapper/benchmark/run.py", line 599, in <module>
    main()  # pragma: no cover
  File "/nethome/iasonm/work/torch_upstream_wrapper/benchmark_wrapper/benchmark/run.py", line 511, in main
    model_flops = get_model_flops(config) if "model_flops" in metrics_needed else None
  File "/nethome/iasonm/work/torch_upstream_wrapper/benchmark_wrapper/benchmark/torchbenchmark/util/experiment/metrics.py", line 129, in get_model_flops
    model = load_model(eager_model_config)
  File "/nethome/iasonm/work/torch_upstream_wrapper/benchmark_wrapper/benchmark/torchbenchmark/util/experiment/instantiator.py", line 90, in load_model
    Model = load_canary_model_by_name(config.name)
  File "/nethome/iasonm/work/torch_upstream_wrapper/benchmark_wrapper/benchmark/torchbenchmark/__init__.py", line 686, in load_canary_model_by_name
    module = importlib.import_module(f".canary_models.{model}", package=__name__)
  File "/usr/lib/python3.10/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1006, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 688, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 883, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/nethome/iasonm/work/torch_upstream_wrapper/benchmark_wrapper/benchmark/torchbenchmark/canary_models/stable_diffusion_xl/__init__.py", line 11, in <module>
    from diffusers import DiffusionPipeline
ModuleNotFoundError: No module named 'diffusers'
```

related task [SQD-965](https://graphcore.atlassian.net/browse/SQD-965)