### PR TITLE
Make test.py run tests using the inductor backend

### DIFF
--- a/test.py
+++ b/test.py
@@ -36,14 +36,17 @@ class TestBenchmark(unittest.TestCase):
         gc.collect()
 
 
-def _create_example_model_instance(task: ModelTask, device: str):
+def _create_example_model_instance(task: ModelTask, device: str, mode: str):
     skip = False
+    extra_args = ["--accuracy"]
+    if mode == "inductor":
+        extra_args.append("--inductor")
     try:
-        task.make_model_instance(test="eval", device=device, extra_args=["--accuracy"])
+        task.make_model_instance(test="eval", device=device, extra_args=extra_args)
     except NotImplementedError:
         try:
             task.make_model_instance(
-                test="train", device=device, extra_args=["--accuracy"]
+                test="train", device=device, extra_args=extra_args
             )
         except NotImplementedError:
             skip = True
@@ -70,7 +73,7 @@ def _load_test(path, device, mode):
             skip=_skip_cuda_memory_check_p(metadata), assert_equal=self.assertEqual
         ):
             try:
-                _create_example_model_instance(task, device)
+                _create_example_model_instance(task, device, mode)
                 accuracy = task.get_model_attribute("accuracy")
                 assert (
                     accuracy == "pass"
@@ -136,7 +139,7 @@ def _load_test(path, device, mode):
             skip=_skip_cuda_memory_check_p(metadata), assert_equal=self.assertEqual
         ):
             try:
-                task.make_model_instance(test="eval", device=device)
+                task.make_model_instance(test="eval", device=device, extra_args=["--inductor"] if mode == "inductor" else [])
                 task.check_device()
                 task.del_model_instance()
             except NotImplementedError as e:
@@ -149,20 +152,20 @@ def _load_test(path, device, mode):
         [example_fn, train_fn, eval_fn, check_device_fn],
         ["example", "train", "eval", "check_device"],
     ):
-        for mode in ["eager", "inductor"]:
-            # set exclude list based on metadata
-            setattr(
-                TestBenchmark,
-                f"test_{model_name}_{fn_name}_{device}" if fn_name in ["example", "check_device"] else f"test_{model_name}_{fn_name}_{device}_{mode}",
-                (
-                    unittest.skipIf(
-                        skip_by_metadata(
-                            test=fn_name, device=device, extra_args=[], metadata=metadata
-                        ),
-                        "This test is skipped by its metadata",
-                    )(fn)
-                ),
-            )
+        # set exclude list based on metadata
+        setattr(
+            TestBenchmark,
+            f"test_{model_name}_{fn_name}_{device}_{mode}",
+            (
+                unittest.skipIf(
+                    # This is expecting that models will never be skipped just based on backend, just on eval or train functions being implemented
+                    skip_by_metadata(
+                        test=fn_name, device=device, extra_args=[], metadata=metadata
+                    ),
+                    "This test is skipped by its metadata",
+                )(fn)
+            ),
+        )
 
 
 def _load_tests():

--- a/test.py
+++ b/test.py
@@ -178,6 +178,10 @@ def _load_tests():
     if os.getenv("USE_CANARY_MODELS"):
         model_paths.extend(_list_canary_model_paths())
     for path in model_paths:
+        # TODO: skipping quantized tests for now due to BC-breaking changes for prepare
+        # api, enable after PyTorch 1.13 release
+        if "quantized" in path:
+            continue
         for device in devices:
             for mode in modes:
                 _load_test(path, device, mode)


### PR DESCRIPTION
As it stands, `test.py` is being used on nightly and pull request workflows in eager mode only (the default for the `Model` class). As inductor is a valid working backend that is also supported by all platforms, we should also validate it via real models in torchbench, specially in PRs.
This should expose pre-existing issues with the current inductor implementation on main and improve the torch.compile coverage, while not extensively increasing the time that PRs take to run with new tests.
This change allows for the discovery of both `eager` and `inductor` backends for `eval` and `train` tests. As the current implementation of the skip mechanism only account for `eval` and `train` being implemented or not, and assuming that any operation that works on `eager` should also work via `inductor`, we only let the metadata skip the test if the `eval` or `train` steps are not implemented for a particular method.
Test collection for each model should look like this now:
```
pytest test.py -k "alexnet" --ignore_machine_config --co

  <Module test.py>
    <UnitTestCase TestBenchmark>
      <TestCaseFunction test_alexnet_check_device_cuda_eager>
      <TestCaseFunction test_alexnet_check_device_cuda_inductor>
      <TestCaseFunction test_alexnet_eval_cuda_eager>
      <TestCaseFunction test_alexnet_eval_cuda_inductor>
      <TestCaseFunction test_alexnet_example_cuda_eager>
      <TestCaseFunction test_alexnet_example_cuda_inductor>
      <TestCaseFunction test_alexnet_train_cuda_eager>
      <TestCaseFunction test_alexnet_train_cuda_inductor>
```
