### PR TITLE
Add quantized tests back

### DIFF
--- a/test.py
+++ b/test.py
@@ -176,10 +176,6 @@ def _load_tests():
     if os.getenv("USE_CANARY_MODELS"):
         model_paths.extend(_list_canary_model_paths())
     for path in model_paths:
-        # TODO: skipping quantized tests for now due to BC-breaking changes for prepare
-        # api, enable after PyTorch 1.13 release
-        if "quantized" in path:
-            continue
         for device in devices:
             _load_test(path, device)
 

--- a/torchbenchmark/util/env_check.py
+++ b/torchbenchmark/util/env_check.py
@@ -30,6 +30,8 @@ UNSUPPORTED_USE_DETERMINISTIC_ALGORITHMS = [
     "Super_SloMo",
     "vgg16",
     "mtml_ctr_instagram_model",
+    "resnet50_quantized_qat",
+    "mobilenet_v2_quantized_qat",
 ]
 CI_SKIP_OPTIMIZER = {
     # TIMM


### PR DESCRIPTION
Quantised models have been skipped for a long time now due to:

```
# TODO: skipping quantized tests for now due to BC-breaking changes for prepare
# api, enable after PyTorch 1.13 release
```

but if enabled, those models work. This also improves the coverage of torchbench by allowing some quantised tests to also be validated for real models (not just unit tests).